### PR TITLE
Use middleware v1.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.12
 
 require (
 	github.com/moesif/moesifapi-go v1.1.2
-	github.com/moesif/moesifmiddleware-go v1.2.4
-
+	github.com/moesif/moesifmiddleware-go v1.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
-github.com/moesif/moesifapi-go v1.1.1/go.mod h1:wRGgVy0QeiCgnjFEiD13HD2Aa7reI8nZXtCnddNnZGs=
 github.com/moesif/moesifapi-go v1.1.2 h1:5Fo6M7VSe8MiXdI3gnU2Z26GmSvMDNBU6aPAxcAnCQU=
 github.com/moesif/moesifapi-go v1.1.2/go.mod h1:wRGgVy0QeiCgnjFEiD13HD2Aa7reI8nZXtCnddNnZGs=
-github.com/moesif/moesifmiddleware-go v1.2.4 h1:PbnifpzJHZfhMEWueqC4EPEBCluQW9VeU8LtSgD2iCs=
-github.com/moesif/moesifmiddleware-go v1.2.4/go.mod h1:1Vru1G7y7vfWeNFEdrx/e+mq8C0be0nNKUxcQqztKck=
+github.com/moesif/moesifmiddleware-go v1.2.5 h1:z+bGySouh7/OXf/8f9WNbKYKSckBcueNgaDJ0wRP0HA=
+github.com/moesif/moesifmiddleware-go v1.2.5/go.mod h1:uDmeNtFXaeqstojURcXFK8uLafrH0exq00Z2tiTv/C0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
This updates the example's dependencies to use the latest moesifmiddleware-go in sync with the latest moesifapi-go